### PR TITLE
Prevents stoppage if table is not found

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -120,18 +120,21 @@ class ConformalBlockTable:
         self.odd_spins = odd_spins
 
         if name != None:
-            dump_file = open(name, 'r')
-            token = next(dump_file)[:4]
-            dump_file.close()
-
-            if token == "self":
+            try:
                 dump_file = open(name, 'r')
-                command = dump_file.read()
-                exec(command)
+                token = next(dump_file)[:4]
                 dump_file.close()
-            else:
-                juliboots_read(self, name)
-            return
+
+                if token == "self":
+                    dump_file = open(name, 'r')
+                    command = dump_file.read()
+                    exec(command)
+                    dump_file.close()
+                else:
+                    juliboots_read(self, name)
+                    return
+            except:
+                print("table "+name+"  not present, generating another")
 
         if dim % 2 == 0:
             small_table = ConformalBlockTableSeed2(dim, k_max, l_max, min(m_max + 2 * n_max, 3), delta_12, delta_34, odd_spins)


### PR DESCRIPTION
If we have a set of tables saved from a previous calculation and suppose we want to run another calculation in which the set of tables required intersects with the old set, this can be useful.

If a table with a given name is not found, instead of stopping, it continues and generates a table anways after mentioning that the table wasn't present.