### PR TITLE
Search for SDPB

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -17,6 +17,8 @@ import xml.dom.minidom
 import time
 import re
 import os
+import subprocess
+
 
 # Regular sympy is slow but we only use it for quick access to Gegenbauer polynomials
 # Even this could be removed since our conformal block code is needlessly general

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1542,6 +1542,8 @@ class SDP:
         zero_threshold: The threshold for identifying a real zero. The determinant
                         over its second derivative must be less than this value.
         """
+        unisolve_path = find_executable("unisolve")
+
         zeros = []
         entries = []
         l = self.get_table_index(spin_irrep)

--- a/common.py
+++ b/common.py
@@ -14,6 +14,14 @@ delta_ext = Symbol('delta_ext')
 
 sdpb_version = 1
 sdpb_path = "/usr/bin/sdpb"
+if not os.path.isfile(sdpb_path):
+    import os
+    for path in os.environ["PATH"].split(os.pathsep):
+        sdpb_path = os.path.join(path, "sdpb")
+        if os.path.isfile(sdpb_path):
+            break
+    else:
+        raise EnvironmentError("SDPB was not found on PATH.")
 sdpb_options = ["checkpointInterval", "maxIterations", "maxRuntime", "dualityGapThreshold", "primalErrorThreshold", "dualErrorThreshold", "initialMatrixScalePrimal", "initialMatrixScaleDual", "feasibleCenteringParameter", "infeasibleCenteringParameter", "stepLengthReduction", "maxComplementarity"]
 sdpb_defaults = ["3600", "500", "86400", "1e-30", "1e-30", "1e-30", "1e+20", "1e+20", "0.1", "0.3", "0.7", "1e+100"]
 if sdpb_version == 1:

--- a/common.py
+++ b/common.py
@@ -16,14 +16,20 @@ ell = Symbol('ell')
 delta  = Symbol('delta')
 delta_ext = Symbol('delta_ext')
 
-sdpb_path = "/usr/bin/sdpb"
-if not os.path.isfile(sdpb_path):
-    for path in os.environ["PATH"].split(os.pathsep):
-        sdpb_path = os.path.join(path, "sdpb")
-        if os.path.isfile(sdpb_path):
-            break
-    else:
-        raise EnvironmentError("SDPB was not found on path.")
+def find_executable(name):
+  if os.path.isfile(name):
+      return name
+  else:
+      for path in os.environ["PATH"].split(os.pathsep):
+          test = os.path.join(path, name)
+          if os.path.isfile(test):
+              return test
+      else:
+          raise EnvironmentError("%s was not found on path." % name)
+
+sdpb_path = find_executable("sdpb")
+
+# Determine (major) version of SDPB
 proc = subprocess.Popen([sdpb_path, "--version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 (stdout, _) = proc.communicate()
 if proc.returncode != 0:
@@ -41,8 +47,7 @@ if sdpb_version == 1:
 else:
     sdpb_options = ["procsPerNode", "procGranularity", "verbosity"] + sdpb_options
     sdpb_defaults = ["4", "1", "1"] + sdpb_defaults
-    mpirun_path = "/usr/bin/mpirun"
-unisolve_path = "/usr/bin/unisolve"
+    mpirun_path = find_executable("mpirun")
 
 def rf(x, n):
     """

--- a/common.py
+++ b/common.py
@@ -25,12 +25,11 @@ if not os.path.isfile(sdpb_path):
     else:
         raise EnvironmentError("SDPB was not found on path.")
 proc = subprocess.Popen([sdpb_path, "--version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-(stdout, stderr) = proc.communicate()
+(stdout, _) = proc.communicate()
 if proc.returncode != 0:
     raise RuntimeError("Failed to invoke SDPB: %s" % sdpb_path)
 m = re.search(r"SDPB ([0-9])", str(stdout))
 if m is None:
-    print(stdout)
     raise RuntimeError("Failed to retrieve SDPB version.")
 sdpb_version = int(m.group(1))
 

--- a/common.py
+++ b/common.py
@@ -12,8 +12,9 @@ ell = Symbol('ell')
 delta  = Symbol('delta')
 delta_ext = Symbol('delta_ext')
 
-# Default path, used as first priority if it exists
+# Default paths, used as first priority if they exists
 sdpb_path = "/usr/bin/sdpb"
+mpirun_path = "/usr/bin/mpirun"
 
 def find_executable(name):
   if os.path.isfile(name):
@@ -51,7 +52,8 @@ if sdpb_version == 1:
 else:
     sdpb_options = ["procsPerNode", "procGranularity", "verbosity"] + sdpb_options
     sdpb_defaults = ["4", "1", "1"] + sdpb_defaults
-    mpirun_path = find_executable("mpirun")
+    if not os.path.isfile(mpirun_path):
+        mpirun_path = find_executable("mpirun")
 
 def rf(x, n):
     """

--- a/common.py
+++ b/common.py
@@ -1,3 +1,7 @@
+import os
+import re
+import subprocess
+
 cutoff = 0
 prec = 660
 dec_prec = int((3.0 / 10.0) * prec)
@@ -12,7 +16,6 @@ ell = Symbol('ell')
 delta  = Symbol('delta')
 delta_ext = Symbol('delta_ext')
 
-sdpb_version = 1
 sdpb_path = "/usr/bin/sdpb"
 if not os.path.isfile(sdpb_path):
     for path in os.environ["PATH"].split(os.pathsep):
@@ -21,6 +24,16 @@ if not os.path.isfile(sdpb_path):
             break
     else:
         raise EnvironmentError("SDPB was not found on path.")
+proc = subprocess.Popen([sdpb_path, "--version"], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+(stdout, stderr) = proc.communicate()
+if proc.returncode != 0:
+    raise RuntimeError("Failed to invoke SDPB: %s" % sdpb_path)
+m = re.search(r"SDPB ([0-9])", str(stdout))
+if m is None:
+    print(stdout)
+    raise RuntimeError("Failed to retrieve SDPB version.")
+sdpb_version = int(m.group(1))
+
 sdpb_options = ["checkpointInterval", "maxIterations", "maxRuntime", "dualityGapThreshold", "primalErrorThreshold", "dualErrorThreshold", "initialMatrixScalePrimal", "initialMatrixScaleDual", "feasibleCenteringParameter", "infeasibleCenteringParameter", "stepLengthReduction", "maxComplementarity"]
 sdpb_defaults = ["3600", "500", "86400", "1e-30", "1e-30", "1e-30", "1e+20", "1e+20", "0.1", "0.3", "0.7", "1e+100"]
 if sdpb_version == 1:

--- a/common.py
+++ b/common.py
@@ -15,13 +15,12 @@ delta_ext = Symbol('delta_ext')
 sdpb_version = 1
 sdpb_path = "/usr/bin/sdpb"
 if not os.path.isfile(sdpb_path):
-    import os
     for path in os.environ["PATH"].split(os.pathsep):
         sdpb_path = os.path.join(path, "sdpb")
         if os.path.isfile(sdpb_path):
             break
     else:
-        raise EnvironmentError("SDPB was not found on PATH.")
+        raise EnvironmentError("SDPB was not found on path.")
 sdpb_options = ["checkpointInterval", "maxIterations", "maxRuntime", "dualityGapThreshold", "primalErrorThreshold", "dualErrorThreshold", "initialMatrixScalePrimal", "initialMatrixScaleDual", "feasibleCenteringParameter", "infeasibleCenteringParameter", "stepLengthReduction", "maxComplementarity"]
 sdpb_defaults = ["3600", "500", "86400", "1e-30", "1e-30", "1e-30", "1e+20", "1e+20", "0.1", "0.3", "0.7", "1e+100"]
 if sdpb_version == 1:


### PR DESCRIPTION
It seems pycftboot does not fail immediately when it doesn't find SDPB.

This PR does four things:
- Searches for SDPB, `mpirun`, and `unisolve` on the user's `PATH`
- Throws an error if SDPB or `mpirun` is not found, so the user knows what is missing
- Automatically determines the major version of SDPB using `sdpb --version`
- Only looks for `unisolve` if necessary (in `extremal_dimensions`)