### PR TITLE
Use subprocess module

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -17,6 +17,7 @@ import xml.dom.minidom
 import time
 import re
 import os
+import subprocess
 
 # Regular sympy is slow but we only use it for quick access to Gegenbauer polynomials
 # Even this could be removed since our conformal block code is needlessly general
@@ -1194,7 +1195,7 @@ class SDP:
 
         if sdpb_version == 2:
             pvm2sdp_path = os.path.dirname(sdpb_path) + "/pvm2sdp"
-            os.spawnvp(os.P_WAIT, mpirun_path, ["mpirun", "-n", "1", pvm2sdp_path, str(prec), name + ".xml", name])
+            subprocess.check_call([mpirun_path, "-n", "1", pvm2sdp_path, str(prec), name + ".xml", name])
 
     def read_output(self, name = "mySDP"):
         """
@@ -1248,10 +1249,10 @@ class SDP:
         self.write_xml(obj, self.unit, name)
 
         if sdpb_version == 1:
-            os.spawnvp(os.P_WAIT, sdpb_path, ["sdpb", "-s", name + ".xml", "--precision=" + str(prec), "--findPrimalFeasible", "--findDualFeasible", "--noFinalCheckpoint"] + self.options)
+            subprocess.check_call([sdpb_path, "-s", name + ".xml", "--precision=" + str(prec), "--findPrimalFeasible", "--findDualFeasible", "--noFinalCheckpoint"] + self.options)
         else:
             ppn = self.get_option("procsPerNode")
-            os.spawnvp(os.P_WAIT, mpirun_path, ["mpirun", "-n", ppn, sdpb_path, "-s", name, "--precision=" + str(prec), "--findPrimalFeasible", "--findDualFeasible"] + self.options)
+            subprocess.check_call([mpirun_path, "-n", ppn, sdpb_path, "-s", name, "--precision=" + str(prec), "--findPrimalFeasible", "--findDualFeasible"] + self.options)
         output = self.read_output(name = name)
 
         terminate_reason = output["terminateReason"]
@@ -1460,10 +1461,10 @@ class SDP:
         self.set_bound(spin_irrep, old)
 
         if sdpb_version == 1:
-            os.spawnvp(os.P_WAIT, sdpb_path, ["sdpb", "-s", name + ".xml", "--precision=" + str(prec), "--noFinalCheckpoint"] + self.options)
+            subprocess.check_call([sdpb_path, "-s", name + ".xml", "--precision=" + str(prec), "--noFinalCheckpoint"] + self.options)
         else:
             ppn = self.get_option("procsPerNode")
-            os.spawnvp(os.P_WAIT, mpirun_path, ["mpirun", "-n", ppn, sdpb_path, "-s", name, "--precision=" + str(prec), "--noFinalCheckpoint"] + self.options)
+            subprocess.check_call([mpirun_path, "-n", ppn, sdpb_path, "-s", name, "--precision=" + str(prec), "--noFinalCheckpoint"] + self.options)
         output = self.read_output(name = name)
         return [one] + output["y"]
 
@@ -1848,9 +1849,9 @@ class SDP:
 
         # SDPB should now run quickly with default options
         if sdpb_version == 1:
-            os.spawnvp(os.P_WAIT, sdpb_path, ["sdpb", "-s", "tmp.xml", "--noFinalCheckpoint"])
+            subprocess.check_call([sdpb_path, "-s", "tmp.xml", "--noFinalCheckpoint"])
         else:
-            os.spawnvp(os.P_WAIT, mpirun_path, ["mpirun", "-n", "1", sdpb_path, "-s", "tmp.xml", "--noFinalCheckpoint"])
+            subprocess.check_call([mpirun_path, "-n", "1", sdpb_path, "-s", "tmp.xml", "--noFinalCheckpoint"])
         output = self.read_output(name = "tmp")
         solution = output["y"]
         solution = solution[zeros + nullity:]


### PR DESCRIPTION
`spawnvp` has been deprecated in favor of [subprocess](https://docs.python.org/2/library/subprocess.html), which also allows checking the return code.

This is useful to fail appropriately when a spawned process fails.

(based on branch `search_path`)