### PR TITLE
Processes per node to SDPB

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1252,7 +1252,7 @@ class SDP:
             subprocess.check_call([sdpb_path, "-s", name + ".xml", "--precision=" + str(prec), "--findPrimalFeasible", "--findDualFeasible", "--noFinalCheckpoint"] + self.options)
         else:
             ppn = self.get_option("procsPerNode")
-            subprocess.check_call([mpirun_path, "-n", ppn, sdpb_path, "-s", name, "--precision=" + str(prec), "--findPrimalFeasible", "--findDualFeasible"] + self.options)
+            subprocess.check_call([mpirun_path, "-n", ppn, sdpb_path, "-s", name, "--precision=" + str(prec), "--findPrimalFeasible", "--findDualFeasible", "--procsPerNode=" + str(ppn)] + self.options)
         output = self.read_output(name = name)
 
         terminate_reason = output["terminateReason"]
@@ -1464,7 +1464,7 @@ class SDP:
             subprocess.check_call([sdpb_path, "-s", name + ".xml", "--precision=" + str(prec), "--noFinalCheckpoint"] + self.options)
         else:
             ppn = self.get_option("procsPerNode")
-            subprocess.check_call([mpirun_path, "-n", ppn, sdpb_path, "-s", name, "--precision=" + str(prec), "--noFinalCheckpoint"] + self.options)
+            subprocess.check_call([mpirun_path, "-n", ppn, sdpb_path, "-s", name, "--precision=" + str(prec), "--noFinalCheckpoint", "--procsPerNode=" + str(ppn)] + self.options)
         output = self.read_output(name = name)
         return [one] + output["y"]
 


### PR DESCRIPTION
Apart from the `-N` flag to `mpirun`, SDPB itself seems to require `--procsPerNode` (as of version 2.3.1-3). Seems like this should be passed to SDPB also.

(based on branch `subprocess`)